### PR TITLE
lexerの修正

### DIFF
--- a/src/lexer.h
+++ b/src/lexer.h
@@ -96,7 +96,7 @@ namespace JsonParser {
                 }
                 break;
             default:
-                chs.push_back(std::string(&ch));
+                chs.push_back(std::string(1, ch));
                 ch = ss.get();
                 break;
             }


### PR DESCRIPTION
Closes #24 

原因はchar型の一時変数`str`のポインタからstringを生成していたこと。
```
std::string(&str)
```
を
```
std::string(1, str)
```
とした。